### PR TITLE
QSP-7: Add input validation

### DIFF
--- a/contracts/xELONChef.sol
+++ b/contracts/xELONChef.sol
@@ -78,6 +78,7 @@ contract xELONChef is Ownable {
         uint256 _startBlock,
         uint256 _bonusEndBlock
     ) public {
+        require(_startBlock < _bonusEndBlock, "_startBlock must come before _bonusEndBlock");
         xelonPerBlock = _xelonPerBlock;
         bonusEndBlock = _bonusEndBlock;
         startBlock = _startBlock;
@@ -88,6 +89,7 @@ contract xELONChef is Ownable {
     }
 
     function setXelon(address _xelon) external onlyOwner {
+        require(_xelon != address(0x0), "Cannot set xElon to the zero address");
         xelon = xELONToken(_xelon);
     }
 
@@ -120,6 +122,7 @@ contract xELONChef is Ownable {
         uint256 _allocPoint,
         bool _withUpdate
     ) public onlyOwner {
+        require(_pid < poolInfo.length, "Specified _pid does not exist");
         if (_withUpdate) {
             massUpdatePools();
         }
@@ -134,6 +137,8 @@ contract xELONChef is Ownable {
         view
         returns (uint256)
     {
+        require(_from < _to, "_from must come before _to");
+        require(_from > startBlock, "_from must come after startBlock");
         if (_to <= bonusEndBlock) {
             return (_to - _from) * BONUS_MULTIPLIER;
         } else if (_from >= bonusEndBlock) {

--- a/contracts/xELONToken.sol
+++ b/contracts/xELONToken.sol
@@ -18,6 +18,7 @@ contract xELONToken is ERC20, AccessControl {
      * @dev Constructor that gives minter role all of existing tokens.
      */
     constructor(address _stakingAddress) ERC20("xELON", "XELON") {
+        require(_stakingAddress != address(0x0), "Cannot set _stakingAddress to the zero address");
         stakingAddress = _stakingAddress;
         // Grant the contract deployer the default admin role: it will be able
         // to grant and revoke any roles


### PR DESCRIPTION
Adds input validation for:
- `constructor()` (for xELONChef)
- `constructor()` (for xELONToken)
- `setXelon()`
- `set()`
- `getMultiplier()`